### PR TITLE
Enable the REST API port for AppDaemon

### DIFF
--- a/appdaemon/config.json
+++ b/appdaemon/config.json
@@ -11,7 +11,8 @@
   "homeassistant_api": true,
   "host_network": false,
   "ports": {
-    "5050/tcp": 5050
+    "5050/tcp": 5050,
+    "5000/tcp": 5000
   },
   "map": [
     "config:rw",


### PR DESCRIPTION
# Proposed Changes

The REST API isn't working with the current docker image configuration. Only one port is opened, when the docker image is created. However we need a second one for the REST API of AppDaemon. 

## Related Issues

[API Calls from outside network - Home Assistant Forum](https://community.home-assistant.io/t/api-calls-from-outside-network/39694/63)